### PR TITLE
auth: idomatic clojure support for user services

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 A Leiningen template for creating useful and productive GAE apps in Clojure 
 using the GAE Java SDK.
 
-## Release 0.2.4-SNAPSHOT
+## Release 0.2.5-SNAPSHOT
 
 Leiningen Clojars dependency:
 
 ```clojure
-[org.clojars.nicolaus/cljgae-template "0.2.4-SNAPSHOT"]
+[org.clojars.nicolaus/cljgae-template "0.2.5-SNAPSHOT"]
 ```
 
 ## Usage
@@ -25,6 +25,7 @@ usage of a few appengine APIs such as
 * The App Identity Service API (via "/" route) 
 * Asyncronous task queues / AKA appengine"push queues" (via a JSON request of 
   a "large" list of data points)
+* User services with user state examples
 
 With unit tests for each. All examples also run on the dev appserver.
 

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,7 @@
-(defproject org.clojars.nicolaus/cljgae-template "0.2.4-SNAPSHOT"
+(defproject org.clojars.nicolaus/cljgae-template "0.2.5-SNAPSHOT"
   :description "cljgae-template is a leiningen template for Google App Engine apps"
   :url "https://github.com/nickbauman/cljgae-template"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :eval-in-leiningen true)
+

--- a/resources/leiningen/new/cljgae_template/appidentity.clj
+++ b/resources/leiningen/new/cljgae_template/appidentity.clj
@@ -1,4 +1,4 @@
-(ns {{name}}.appengine
+(ns {{name}}.appidentity
   (:require [clj-time.coerce :as c]
             [{{name}}.util :refer :all])
   (:import [com.google.appengine.api.utils SystemProperty]

--- a/resources/leiningen/new/cljgae_template/auth.clj
+++ b/resources/leiningen/new/cljgae_template/auth.clj
@@ -1,0 +1,27 @@
+(ns {{name}}.auth
+    (:import [com.google.appengine.api.users UserService UserServiceFactory]))
+
+(defn juser-service-factory []
+  (UserServiceFactory/getUserService))
+
+(defn jcurrent-user []
+  (.getCurrentUser (juser-service-factory)))
+
+(defn user-logged-in? []
+  (.isUserLoggedIn (juser-service-factory)))
+
+(defn user-admin? []
+  (if (user-logged-in?)
+    (.isUserAdmin (juser-service-factory))
+    false))
+
+(defn create-login-url
+  ([destination-url] (.createLoginURL (juser-service-factory) destination-url))
+  ([destination-url auth-domain] (.createLoginURL (juser-service-factory) destination-url auth-domain))
+  ([destination-url auth-domain fed-identity attributes-from-req]
+   (.createLoginURL (juser-service-factory) destination-url auth-domain fed-identity attributes-from-req)))
+
+(defn create-logout-url
+  ([destination-url] (.createLogoutURL (juser-service-factory) destination-url))
+  ([destination-url auth-domain] (.createLogoutURL (juser-service-factory) destination-url auth-domain)))
+

--- a/resources/leiningen/new/cljgae_template/env.clj
+++ b/resources/leiningen/new/cljgae_template/env.clj
@@ -1,5 +1,5 @@
 (ns {{name}}.env
-  (:require [{{name}}.appengine :as a]))
+  (:require [{{name}}.appidentity :as a]))
 
 (def environment (let [app-eng-env (a/environment)
                        app-name (a/application-id)]

--- a/resources/leiningen/new/cljgae_template/test_appidentity.clj
+++ b/resources/leiningen/new/cljgae_template/test_appidentity.clj
@@ -1,8 +1,8 @@
-(ns {{name}}.test.appengine
+(ns {{name}}.test.appidentity
     (:require [clojure.test :refer :all]
               [clj-time.coerce :as c]
               [{{name}}.test.fixtures :as fixtures]
-              [{{name}}.appengine :refer :all]))
+              [{{name}}.appidentity :refer :all]))
 
 (use-fixtures :once fixtures/setup-local-service-test-helper)
 

--- a/resources/leiningen/new/cljgae_template/test_auth.clj
+++ b/resources/leiningen/new/cljgae_template/test_auth.clj
@@ -1,0 +1,11 @@
+(ns {{name}}.test.auth
+    (:require [clojure.test :refer :all]
+              [{{name}}.test.fixtures :as fixtures]
+              [{{name}}.auth :refer :all]))
+
+(use-fixtures :once fixtures/setup-local-service-test-helper)
+
+(deftest user-test
+  (is (= "/_ah/login?continue=%2Ffff" (create-login-url "/fff")))
+  (is (= "/_ah/logout?continue=%2Ffff" (create-logout-url "/fff"))))
+

--- a/resources/leiningen/new/cljgae_template/view.clj
+++ b/resources/leiningen/new/cljgae_template/view.clj
@@ -1,7 +1,8 @@
 (ns {{name}}.view
   (:require [hiccup.page :as page]
-    [{{name}}.push-queue :as pg]
-    [{{name}}.appengine :refer [sdk-version app-version
+    [{{name}}.auth :as auth]
+    [{{name}}.push-queue :as pq]
+    [{{name}}.appidentity :refer [sdk-version app-version
                            application-id environment
                            last-deployed-datetime]]
     [{{name}}.env :as env]
@@ -9,7 +10,7 @@
     [clj-time.core :as t]))
 
 (defn- module-hostname [request]
-  (or (pg/get-module-hostname)
+  (or (pq/get-module-hostname)
     (get-in request [:headers "host"])))
 
 (defn- tr [type & cols]
@@ -23,26 +24,39 @@
   (page/html5 
    [:head
     [:title title]
-    (page/include-css "//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css")]
+    (page/include-css "//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css")
+    (page/include-css "//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css")]
    [:body
+    [:ul {:class "nav nav-pills"}
+     [:li {:role "presentation" :class "active"} [:a {:href "/"} "Home"]]
+     (if (auth/user-logged-in?)
+       [:li {:role "presentation" :class "active"} [:a {:href (auth/create-logout-url "/")} "Log Out"]]
+       [:li {:role "presentation" :class "active"} [:a {:href (auth/create-login-url "/")}  "Log In"]])
+     ]
     [:div {:class "container"}
      [:h1 heading]
      (when (seq more)
        more)]
-    (page/include-js "//code.jquery.com/jquery-2.1.1.min.js")
-    (page/include-js "//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js")]))
+    (page/include-js "//code.jquery.com/jquery-3.1.1.min.js")
+    (page/include-js "//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js")]))
 
-(defn home [request]
+(defn home [request]  
   (base request "{{name}} App Engine App" "{{name}}"
-        [:table {:class "table table-bordered table-striped table-condensed"}
-         (tr :th "Property" "Value")
-         (tr :td "Application Id" (application-id))
-         (tr :td "Version" (app-version))
-         (tr :td "Module Hostname" (module-hostname request))
-         (tr :td "GCS Bucket" env/gcs-bucket-name)
-         (tr :td "Last Deployed At" (f/unparse formatter (last-deployed-datetime)))
-         (tr :td "Environment" (environment))
-         (tr :td "SDK Version" (sdk-version))]))
+        (if (auth/user-admin?)
+          [:div {:class "panel panel-default"}
+           [:div {:class "panel-heading"} "App Identity API values"]
+           [:div {:class "panel-body"} [:p "Remember dev-appserver has stubbed versions of these. In prod this information is a lot more interesting."]]
+           [:table {:class "table table-bordered table-striped table-condensed"}
+            (tr :th "Property" "Value")
+            (tr :td "Application Id" (application-id))
+            (tr :td "Version" (app-version))
+            (tr :td "Module Hostname" (module-hostname request))
+            (tr :td "GCS Bucket" env/gcs-bucket-name)
+            (tr :td "Last Deployed At" (f/unparse formatter (last-deployed-datetime)))
+            (tr :td "Environment" (environment))
+            (tr :td "SDK Version" (sdk-version))]
+           ]
+          [:h3 "Welcome..."])))
 
 (defn file-upload-form [request & more]
   (base request "{{name}} | file upload example" "File Upload Example"

--- a/resources/leiningen/new/cljgae_template/web.xml
+++ b/resources/leiningen/new/cljgae_template/web.xml
@@ -11,6 +11,7 @@
     <url-pattern>/*</url-pattern>
   </servlet-mapping>
  
+  <!--
   <security-constraint>
         <web-resource-collection>
             <web-resource-name>admin</web-resource-name>
@@ -20,4 +21,5 @@
             <role-name>admin</role-name>
         </auth-constraint>
     </security-constraint>
+  -->
 </web-app>

--- a/src/leiningen/new/cljgae_template.clj
+++ b/src/leiningen/new/cljgae_template.clj
@@ -13,7 +13,8 @@
     (main/info (str "Generating new cljgae-template project '" name "'"))
     (->files data
              ; {{name}} package
-             ["src/{{sanitized}}/appengine.clj" (render "appengine.clj" data)]
+             ["src/{{sanitized}}/appidentity.clj" (render "appidentity.clj" data)]
+             ["src/{{sanitized}}/auth.clj" (render "auth.clj" data)]
              ["src/{{sanitized}}/db.clj" (render "db.clj" data)]
              ["src/{{sanitized}}/env.clj" (render "env.clj" data)]
              ["src/{{sanitized}}/gcs.clj" (render "gcs.clj" data)]
@@ -27,7 +28,8 @@
              ["test/{{sanitized}}/test/file_example.jpg" (render "file_example.jpg" data)]
              ["test/{{sanitized}}/test/events.json" (render "events.json" data)]
              ["test/{{sanitized}}/test/fixtures.clj" (render "fixtures.clj" data)]
-             ["test/{{sanitized}}/test/appengine.clj" (render "test_appengine.clj" data)]
+             ["test/{{sanitized}}/test/appidentity.clj" (render "test_appidentity.clj" data)]
+             ["test/{{sanitized}}/test/auth.clj" (render "test_auth.clj" data)]
              ["test/{{sanitized}}/test/db.clj" (render "test_db.clj" data)]
              ["test/{{sanitized}}/test/handler.clj" (render "test_handler.clj" data)]
              ["test/{{sanitized}}/test/helpers.clj" (render "helpers.clj" data)]


### PR DESCRIPTION
- Renames appengine.clj to appidentity.clj because more appropriate.
- Adds user login / logout in auth.clj
- Uses it in views.clj
- Simple tests